### PR TITLE
Make CMSessionParams public.

### DIFF
--- a/src/main/java/org/igniterealtime/jbosh/CMSessionParams.java
+++ b/src/main/java/org/igniterealtime/jbosh/CMSessionParams.java
@@ -21,7 +21,7 @@ package org.igniterealtime.jbosh;
  * configuration knowledge related to the CM session and provides a
  * mechanism by which
  */
-final class CMSessionParams {
+public final class CMSessionParams {
 
     private final AttrSessionID sid;
 

--- a/src/main/java/org/igniterealtime/jbosh/StaticBody.java
+++ b/src/main/java/org/igniterealtime/jbosh/StaticBody.java
@@ -28,15 +28,15 @@ import java.util.Map;
  * this class are based on the underlying data and therefore cannot be
  * modified.  In order to obtain the wrapper element namespace and
  * attribute information, the body content is partially parsed.
- * <p/>
+ * <p>
  * This class does only minimal syntactic and semantic checking with respect
  * to what the generated XML will look like.  It is up to the developer to
  * protect against the definition of malformed XML messages when building
  * instances of this class.
- * <p/>
+ * </p>
  * Instances of this class are immutable and thread-safe.
  */
-final class StaticBody extends AbstractBody {
+public final class StaticBody extends AbstractBody {
 
     /**
      * Selected parser to be used to process raw XML messages.


### PR DESCRIPTION
This makes https://github.com/igniterealtime/jbosh/commit/03e5d487b1e597df06a9f079704bcea99e298230 complete.
-  Without CMSessionParams being public the public HTTPSender interface is unusable.
-  In order to effectively implement the HTTPSender interface, StaticBody must be used to create an AbstractBody.
