### PR TITLE
added ability to enable/disable acknowledgements

### DIFF
--- a/src/main/java/org/igniterealtime/jbosh/BOSHClient.java
+++ b/src/main/java/org/igniterealtime/jbosh/BOSHClient.java
@@ -859,7 +859,12 @@ public final class BOSHClient {
         builder.setAttribute(Attributes.RID, Long.toString(rid));
         applyRoute(builder);
         applyFrom(builder);
-        builder.setAttribute(Attributes.ACK, "1");
+        // NOTE: waiting for acknowledgment in every packet slows down connection
+        // because it postpones sending every packet until previous ack is received.
+        // it's can be observed especially on mobile device client with 1 processing thread.
+        if (cfg.isAckEnabled() ) {
+            builder.setAttribute(Attributes.ACK, "1");
+        }
 
         // Make sure the following are NOT present (i.e., during retries)
         builder.setAttribute(Attributes.SID, null);
@@ -915,7 +920,10 @@ public final class BOSHClient {
         builder.setAttribute(Attributes.SID,
                 cmParams.getSessionID().toString());
         builder.setAttribute(Attributes.RID, Long.toString(rid));
-        applyResponseAcknowledgement(builder, rid);
+
+        if(cfg.isAckEnabled()) {
+            applyResponseAcknowledgement(builder, rid);
+        }
         return builder.build();
     }
 

--- a/src/main/java/org/igniterealtime/jbosh/BOSHClientConfig.java
+++ b/src/main/java/org/igniterealtime/jbosh/BOSHClientConfig.java
@@ -75,6 +75,15 @@ public final class BOSHClientConfig {
      */
     private final boolean compressionEnabled;
 
+    /**
+     * Flag indicating that acknowledgements will be using for session.
+     *
+     * According to https://xmpp.org/extensions/xep-0124.html
+     * A client MAY include an 'ack' attribute (set to "1") to indicate that it will be using acknowledgements
+     * throughout the session and that the absence of an 'ack' attribute in any request is meaningful (see Acknowledgements).
+     */
+    private final boolean ack;
+
     ///////////////////////////////////////////////////////////////////////////
     // Classes:
 
@@ -100,6 +109,7 @@ public final class BOSHClientConfig {
         private int bProxyPort;
         private SSLContext bSSLContext;
         private Boolean bCompression;
+        private boolean ack = true;
 
         /**
          * Creates a new builder instance, used to create instances of the
@@ -279,6 +289,19 @@ public final class BOSHClientConfig {
         }
 
         /**
+         * Set whether or not acknowledgements throughout the session
+         * should be enabled.  By default, acknowledgement is enabled.
+         *
+         * @param enabled set to {@code true} if an acknowledgements throughout the session
+         * should be using
+         * @return builder instance
+         */
+        public Builder setAckEnabled(boolean enabled) {
+            ack = enabled;
+            return this;
+        }
+
+        /**
          * Build the immutable object instance with the current configuration.
          *
          * @return BOSHClientConfig instance
@@ -317,7 +340,8 @@ public final class BOSHClientConfig {
                     bProxyHost,
                     port,
                     bSSLContext,
-                    compression);
+                    compression,
+                    ack);
         }
 
     }
@@ -347,7 +371,8 @@ public final class BOSHClientConfig {
             final String cProxyHost,
             final int cProxyPort,
             final SSLContext cSSLContext,
-            final boolean cCompression) {
+            final boolean cCompression,
+            final boolean useAck) {
         uri = cURI;
         to = cDomain;
         from = cFrom;
@@ -357,6 +382,7 @@ public final class BOSHClientConfig {
         proxyPort = cProxyPort;
         sslContext = cSSLContext;
         compressionEnabled = cCompression;
+        ack = useAck;
     }
 
     /**
@@ -444,5 +470,7 @@ public final class BOSHClientConfig {
     boolean isCompressionEnabled() {
         return compressionEnabled;
     }
+
+    public boolean isAckEnabled() { return ack; }
 
 }


### PR DESCRIPTION
According to https://xmpp.org/extensions/xep-0124.html
A client MAY include an 'ack' attribute (set to "1") to indicate that it will be using acknowledgements. Key word is MAY.
Waiting for acknowledgment in every packet slows down connection, especially on mobile device client with 1 processing thread.

The case is:
-  Establish connection with acknowledgement using 1 processing thread.
- Send a message with "ack" attribute to server. Server doesn't immediately answer but hold HTTP connection during  "wait" period and then answer. Standard "wait" period :15-30sec.
- Sending every next messages while answer isn't received for previous leads to queuing messages.

If we disable "ack" attribute server will answer immediately. 

Suppose we send 3 messages, 3rd message will be sent after 1 minute and so on. On mobile device it's a huge delay. 
To track message status without "ack" mechanism.we can rely on http status and timeout for sending messages.   

