### PR TITLE
Upgrade apache http client to 4.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ repositories {
 
 dependencies {
 	compile 'xpp3:xpp3:1.1.4c'
-	compile 'org.apache.httpcomponents:httpclient:4.3.3'
+	compile 'org.apache.httpcomponents:httpclient:4.5.5'
 	testCompile 'org.xlightweb:xlightweb:2.5'
 	testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
Note that with this change, we are also using the SSLContext
from the configurations. That will introduce a change
to the past behaviour, which used a hard-coded noop
SSL host verifier.