### PR TITLE
Allow sending different BOSH protocol versions

### DIFF
--- a/src/main/java/org/igniterealtime/jbosh/AttrVersion.java
+++ b/src/main/java/org/igniterealtime/jbosh/AttrVersion.java
@@ -20,7 +20,7 @@ package org.igniterealtime.jbosh;
  * Data type representing the getValue of the {@code ver} attribute of the
  * {@code bosh} element.
  */
-final class AttrVersion extends AbstractAttr<String> {
+public final class AttrVersion extends AbstractAttr<String> {
 
     /**
      * Default value if none is provided.
@@ -106,7 +106,7 @@ final class AttrVersion extends AbstractAttr<String> {
      *  {@code null}
      * @throws BOSHException on parse or validation failure
      */
-    static AttrVersion createFromString(final String str)
+    public static AttrVersion createFromString(final String str)
     throws BOSHException {
         if (str == null) {
             return null;

--- a/src/main/java/org/igniterealtime/jbosh/BOSHClient.java
+++ b/src/main/java/org/igniterealtime/jbosh/BOSHClient.java
@@ -849,7 +849,7 @@ public final class BOSHClient {
         builder.setAttribute(Attributes.TO, cfg.getTo());
         builder.setAttribute(Attributes.XML_LANG, cfg.getLang());
         builder.setAttribute(Attributes.VER,
-                AttrVersion.getSupportedVersion().toString());
+                cfg.getBoshVersion().toString());
         // NOTE: when WAIT is set to 60, HOLD is set to 1 and the CM replies
         // with REQ = 1 then the connection can end up stuck up to 60 seconds
         // if empty request is sent and there is no incoming traffic during that

--- a/src/main/java/org/igniterealtime/jbosh/BOSHClientConfig.java
+++ b/src/main/java/org/igniterealtime/jbosh/BOSHClientConfig.java
@@ -93,6 +93,11 @@ public final class BOSHClientConfig {
      */
     private List<Header> httpHeaders;
 
+    /**
+     * Version of the BOSH protocol.
+     */
+    private AttrVersion boshVersion;
+
     ///////////////////////////////////////////////////////////////////////////
     // Classes:
 
@@ -120,6 +125,7 @@ public final class BOSHClientConfig {
         private Boolean bCompression;
         private boolean ack = true;
         private List<Header> httpHeaders = new ArrayList<>();
+        private AttrVersion boshVersion = AttrVersion.getSupportedVersion();
 
         /**
          * Creates a new builder instance, used to create instances of the
@@ -324,6 +330,23 @@ public final class BOSHClientConfig {
         }
 
         /**
+         * Version of the BOSH communication to be sent over to the server.
+         *
+         * The version, by default, is the latest version that this library supports.
+         * But in some cases, the server expects a different version, and would
+         * reject the connection otherwise. So change it on your own risk.
+         * See <a href="https://xmpp.org/extensions/xep-0124.html#appendix-revs">list of versions</a>
+         *
+         * @param version of the protocol to be sent over to the server
+         * @return builder instance
+         */
+        public Builder setBoshVersion(AttrVersion version) {
+            this.boshVersion = version;
+            return this;
+        }
+
+
+        /**
          * Build the immutable object instance with the current configuration.
          *
          * @return BOSHClientConfig instance
@@ -364,7 +387,8 @@ public final class BOSHClientConfig {
                     bSSLContext,
                     compression,
                     ack,
-                    httpHeaders);
+                    httpHeaders,
+                    boshVersion);
         }
 
     }
@@ -374,8 +398,7 @@ public final class BOSHClientConfig {
 
     /**
      * Prevent direct construction.
-     *
-     * @param cURI URI of the connection manager to connect to
+     *  @param cURI URI of the connection manager to connect to
      * @param cDomain the target domain of the first stream
      * @param cFrom client ID
      * @param cLang default XML language
@@ -384,6 +407,7 @@ public final class BOSHClientConfig {
      * @param cProxyPort proxy port
      * @param cSSLContext SSL context
      * @param cCompression compression enabled flag
+     * @param cBoshVersion version of the protocol to be sent over
      */
     private BOSHClientConfig(
             final URI cURI,
@@ -396,7 +420,8 @@ public final class BOSHClientConfig {
             final SSLContext cSSLContext,
             final boolean cCompression,
             final boolean useAck,
-            final List<Header> cHttpHeaders) {
+            final List<Header> cHttpHeaders,
+            AttrVersion cBoshVersion) {
         uri = cURI;
         to = cDomain;
         from = cFrom;
@@ -408,6 +433,7 @@ public final class BOSHClientConfig {
         compressionEnabled = cCompression;
         ack = useAck;
         httpHeaders = cHttpHeaders;
+        boshVersion = cBoshVersion;
     }
 
     /**
@@ -502,4 +528,7 @@ public final class BOSHClientConfig {
         return httpHeaders;
     }
 
+    public AttrVersion getBoshVersion() {
+        return boshVersion;
+    }
 }


### PR DESCRIPTION
In case the BOSH server expects a specific BOSH protocol version
for the communication, allow this client to communicate that version
to the server.