### PR TITLE
Fixes a case where we are trying to send a message to closed client.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,11 @@ android:
 jdk:
   - oraclejdk8
 
+before_install:
+  - export GRADLE_VERSION=5.4.1
+  - wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-all.zip
+  - unzip -q gradle-${GRADLE_VERSION}-all.zip
+  - export PATH="$(pwd)/gradle-${GRADLE_VERSION}/bin:$PATH"
+
 install: gradle assemble
 script: gradle check

--- a/src/main/java/org/igniterealtime/jbosh/BOSHClient.java
+++ b/src/main/java/org/igniterealtime/jbosh/BOSHClient.java
@@ -695,6 +695,14 @@ public final class BOSHClient {
                 processor.dispose();
             }
             procThreads = null;
+
+            clearEmptyRequest();
+            exchanges = null;
+            cmParams = null;
+            pendingResponseAcks = null;
+            pendingRequestAcks = null;
+            notEmpty.signalAll();
+            notFull.signalAll();
         } finally {
             lock.unlock();
         }
@@ -707,18 +715,11 @@ public final class BOSHClient {
 
         lock.lock();
         try {
-            clearEmptyRequest();
-            exchanges = null;
-            cmParams = null;
-            pendingResponseAcks = null;
-            pendingRequestAcks = null;
-            notEmpty.signalAll();
-            notFull.signalAll();
             drained.signalAll();
         } finally {
             lock.unlock();
         }
-        
+
         httpSender.destroy();
         schedExec.shutdownNow();
     }


### PR DESCRIPTION
All calls waiting in blockUntilSendable should be notified on closing
before reporting state. Fixes the following case:

```
"RequestProcessor[928450352]: Receive thread 0" #403429 daemon prio=5 os_prio=0 tid=0x00007f9d5838f000 nid=0x5c1c waiting for monitor entry [0x00007f9cee90d000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.jivesoftware.smack.bosh.XMPPBOSHConnection$BOSHConnectionListener.connectionEvent(XMPPBOSHConnection.java:471)
	- waiting to lock <0x0000000701e8c1d0> (a org.jivesoftware.smack.bosh.XMPPBOSHConnection)
	at org.igniterealtime.jbosh.BOSHClient.fireConnectionClosedOnError(BOSHClient.java:1683)
	at org.igniterealtime.jbosh.BOSHClient.dispose(BOSHClient.java:705)
	at org.igniterealtime.jbosh.BOSHClient.processExchange(BOSHClient.java:1137)
	at org.igniterealtime.jbosh.BOSHClient.processMessages(BOSHClient.java:998)
	at org.igniterealtime.jbosh.BOSHClient.access$300(BOSHClient.java:100)
	at org.igniterealtime.jbosh.BOSHClient$RequestProcessor.run(BOSHClient.java:1727)
	at java.lang.Thread.run(Thread.java:748)

"Thread-178504" #404967 daemon prio=10 os_prio=0 tid=0x00007f9d080bc800 nid=0x31c5 waiting on condition [0x00007f9ce6f94000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x0000000701e8ef20> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2039)
	at org.igniterealtime.jbosh.BOSHClient.blockUntilSendable(BOSHClient.java:829)
	at org.igniterealtime.jbosh.BOSHClient.send(BOSHClient.java:485)
	at org.jivesoftware.smack.bosh.XMPPBOSHConnection.send(XMPPBOSHConnection.java:323)
	at org.jivesoftware.smack.bosh.XMPPBOSHConnection.sendElement(XMPPBOSHConnection.java:244)
	at org.jivesoftware.smack.bosh.XMPPBOSHConnection.sendStanzaInternal(XMPPBOSHConnection.java:239)
	at org.jivesoftware.smack.AbstractXMPPConnection.sendStanza(AbstractXMPPConnection.java:685)
	at org.jivesoftware.smack.AbstractXMPPConnection.disconnect(AbstractXMPPConnection.java:732)
	- locked <0x0000000701e8c1d0> (a org.jivesoftware.smack.bosh.XMPPBOSHConnection)
```